### PR TITLE
votaciones - 003 - Opción de incluirse en el Censo

### DIFF
--- a/decide/voting/admin.py
+++ b/decide/voting/admin.py
@@ -1,9 +1,12 @@
+from django import forms
 from django.contrib import admin
 from django.utils import timezone
+from rangefilter.filter import DateRangeFilter, DateTimeRangeFilter
 
 from .models import QuestionOption
 from .models import Question
 from .models import Voting
+from census.models import Census
 
 from .filters import StartedFilter
 
@@ -34,16 +37,32 @@ class QuestionOptionInline(admin.TabularInline):
 class QuestionAdmin(admin.ModelAdmin):
     inlines = [QuestionOptionInline]
 
+class VotingModel(forms.ModelForm):
+    autocenso = forms.BooleanField(required=False)
+
+    class Meta:
+        model = Voting
+        exclude = []
+
 
 class VotingAdmin(admin.ModelAdmin):
     list_display = ('name', 'start_date', 'end_date')
     readonly_fields = ('start_date', 'end_date', 'pub_key',
                        'tally', 'postproc')
-    date_hierarchy = 'start_date'
-    list_filter = (StartedFilter,)
+    # date_hierarchy = 'start_date'
+    # list_filter = (StartedFilter,)
+    list_filter = (StartedFilter, ('start_date', DateRangeFilter), ('end_date', DateRangeFilter),)
     search_fields = ('name', )
 
     actions = [ start, stop, tally ]
+    form =VotingModel
+
+    def save_model(self, request, obj, form, change):
+        super(VotingAdmin, self).save_model(request, obj, form, change)
+        if form.cleaned_data.get('autocenso'):
+            user = request.user
+            Census.objects.get_or_create(voter_id=user.id, voting_id=obj.id)
+
 
 
 admin.site.register(Voting, VotingAdmin)


### PR DESCRIPTION
En esta tarea realizamos una mejora, que simplifica la creación de una votación mediante un chackbox que permite de forma programática la inclusión del creador de la votación en el censo de votantes. Reduciendo el número de clicks necesarios para realizar pruebas de votaciones.

Se ha tocado el admin.py de votaciones, añadiendo diferentes métodos para la realización de la tarea previamente descrita.