### PR TITLE
votaciones 005 -  Impedir creación de preguntas con la misma descripción

### DIFF
--- a/decide/voting/models.py
+++ b/decide/voting/models.py
@@ -8,7 +8,7 @@ from base.models import Auth, Key
 
 
 class Question(models.Model):
-    desc = models.TextField()
+    desc = models.TextField(unique=True)
 
     def __str__(self):
         return self.desc

--- a/decide/voting/tests.py
+++ b/decide/voting/tests.py
@@ -14,6 +14,8 @@ from mixnet.mixcrypt import ElGamal
 from mixnet.mixcrypt import MixCrypt
 from mixnet.models import Auth
 from voting.models import Voting, Question, QuestionOption
+from django.db.utils import IntegrityError
+
 
 
 class VotingTestCase(BaseTestCase):
@@ -46,6 +48,11 @@ class VotingTestCase(BaseTestCase):
         v.auths.add(a)
 
         return v
+    
+    def create_question(self):
+        q = Question(desc='test question')
+        q.save()
+        return q
 
     def create_voters(self, v):
         for i in range(100):
@@ -105,6 +112,13 @@ class VotingTestCase(BaseTestCase):
 
         for q in v.postproc:
             self.assertEqual(tally.get(q["number"], 0), q["votes"])
+    
+    def test_question_unique(self):
+        v = self.create_question()
+        with self.assertRaises(Exception) as raised:
+            self.create_question()
+        self.assertEqual(IntegrityError, type(raised.exception))
+
 
     def test_create_voting_from_api(self):
         data = {'name': 'Example'}

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ djangorestframework==3.7.7
 django-cors-headers==2.1.0
 requests==2.18.4
 django-filter==1.1.0
-psycopg2==2.7.4
+psycopg2==2.8.4
 django-rest-swagger==2.2.0
 coverage==4.5.2
 django-nose==1.4.6


### PR DESCRIPTION
Añadida característica de no poder crear dos preguntas en una votación con una misma descripción