### PR TITLE
votaciones 001 - Impedir creación de dos votaciones con el mismo nombre

### DIFF
--- a/decide/voting/models.py
+++ b/decide/voting/models.py
@@ -29,7 +29,7 @@ class QuestionOption(models.Model):
 
 
 class Voting(models.Model):
-    name = models.CharField(max_length=200)
+    name = models.CharField(max_length=200, unique = True)
     desc = models.TextField(blank=True, null=True)
     question = models.ForeignKey(Question, related_name='voting', on_delete=models.CASCADE)
 

--- a/decide/voting/tests.py
+++ b/decide/voting/tests.py
@@ -4,6 +4,7 @@ from django.utils import timezone
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import TestCase
+from django.db.utils import IntegrityError
 from rest_framework.test import APIClient
 from rest_framework.test import APITestCase
 
@@ -105,6 +106,12 @@ class VotingTestCase(BaseTestCase):
 
         for q in v.postproc:
             self.assertEqual(tally.get(q["number"], 0), q["votes"])
+
+    def test_duplicate_voting_name(self):
+        v1 = self.create_voting()
+        with self.assertRaises(Exception) as raised:
+            v2 = self.create_voting()
+        self.assertEqual(IntegrityError, type(raised.exception))
 
     def test_create_voting_from_api(self):
         data = {'name': 'Example'}

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ djangorestframework==3.7.7
 django-cors-headers==2.1.0
 requests==2.18.4
 django-filter==1.1.0
-psycopg2==2.7.4
+psycopg2-binary==2.8.4
 django-rest-swagger==2.2.0
 coverage==4.5.2
 django-nose==1.4.6


### PR DESCRIPTION
Implementada la restricción de no crear dos votaciones con el mismo nombre. También implementada la prueba unitaria para la restricción.