### PR TITLE
votaciones i017 - Soporte a corrección de error en el modelo (Visualización -> Votaciones)

### DIFF
--- a/decide/voting/serializers.py
+++ b/decide/voting/serializers.py
@@ -18,7 +18,7 @@ class QuestionSerializer(serializers.HyperlinkedModelSerializer):
 
 
 class VotingSerializer(serializers.HyperlinkedModelSerializer):
-    question = QuestionSerializer(many=False)
+    question = QuestionSerializer(many=True)
     pub_key = KeySerializer()
     auths = AuthSerializer(many=True)
 


### PR DESCRIPTION
Cambio del QuestionSerializer en la linea 21 del archivo serializers.py de votings de False a True para que el módulo de visualización pueda acceder a las preguntas