### PR TITLE
votaciones h021 - Modificación del método give_message al realizar tally, eliminación de a y b de serializers y adicion de return a los métodos de tally

### DIFF
--- a/decide/store/serializers.py
+++ b/decide/store/serializers.py
@@ -4,10 +4,6 @@ from .models import Vote
 
 
 class VoteSerializer(serializers.HyperlinkedModelSerializer):
-    a = serializers.IntegerField()
-    b = serializers.IntegerField()
-    c = serializers.IntegerField()
-    d = serializers.IntegerField()
 
     class Meta:
         model = Vote

--- a/decide/voting/admin.py
+++ b/decide/voting/admin.py
@@ -32,14 +32,14 @@ def stop(ModelAdmin, request, queryset):
 def tally(ModelAdmin, request, queryset):
     for v in queryset.filter(end_date__lt=timezone.now()):
         token = request.session.get('auth-token', '')
-        v.tally_votes(token)
-        respuesta=give_message(v)
+        tally=v.tally_votes(token)
+        respuesta=give_message(v,tally)
         messages.info(request,respuesta)
 
 
-def give_message(v):
+def give_message(v,tally):
     mensj=""
-    votos = v.votes_info_votos()
+    votos = v.votes_info_votos(tally)
     for voto in votos:
         pregunta = voto['pregunta']
         mensj = mensj + "for question " + pregunta

--- a/decide/voting/models.py
+++ b/decide/voting/models.py
@@ -144,9 +144,10 @@ class Voting(models.Model):
         self.tally = response.json()
         self.save()
 
+        tally=self.tally
+        return tally
         self.tally_votes_masc(token)
-        self.votes_info_votos()
-    
+        return tally
     def tally_votes_masc(self, token=''):
         '''
         The tally is a shuffle and then a decrypt
@@ -188,7 +189,10 @@ class Voting(models.Model):
         self.tallyM = response.json()
         self.save()
 
+        tallyM=self.tallyM
+
         self.tally_votes_fem(token)
+        return tallyM
     
     def tally_votes_fem(self, token=''):
         '''
@@ -230,7 +234,9 @@ class Voting(models.Model):
         self.tallyF = response.json()
         self.save()
 
+        tallyF=self.tallyF
         self.do_postproc()
+        return tallyF
       
 
 
@@ -238,9 +244,8 @@ class Voting(models.Model):
 
    
 
-    def votes_info_votos(self):
+    def votes_info_votos(self,tally):
         data=[]
-        tally = self.tally
         for i, q in enumerate(self.question.all()):
             opciones = q.options.all()
             opt_count=len(opciones)


### PR DESCRIPTION
Se ha modificado el método give_message al realizar el tally de una votación de forma que cada vez que se le llame se le pase el objeto tally devuelto por el método tally_votes en lugar del objeto votación, que tiene más sentido.También se ha eliminado de serializers de store a y b, que no estaban siendo usadas, y se ha añadido return a los métodos de tally para poder acceder a sus objetos