### PR TITLE
cabina - 029 - Añadir un error descriptivo al realizar un segundo voto

### DIFF
--- a/decide/booth/templates/booth/booth.html
+++ b/decide/booth/templates/booth/booth.html
@@ -219,6 +219,9 @@
             showAlert(lvl, msg) {
                 this.alertLvl = lvl;
                 this.alertMsg = msg;
+                if (msg.includes('Forbidden')) {
+                    this.alertMsg = 'No puedes realizar la votación.'
+                }
                 this.alertShow = true;
             }
         },


### PR DESCRIPTION
Se ha añadido una descripción genérica del error que se muestra cuando se lance un código de error 403 en la interfaz de cabina.
Para crear un nuevo status_code es necesario mucho más tiempo, por lo que he decidido implementar una solución efectiva y rápida a nivel de interfaz en booth.html.

Creo que no es necesario que corrija los posibles errores que muestre Codacy porque serán los mismos que te ocurran a ti en la incidencia que estás solucionando.