### PR TITLE
Task t061: Pruebas de modelo para corroborar la creación correcta del identificador de recuento de votos

### DIFF
--- a/decide/voting/tests.py
+++ b/decide/voting/tests.py
@@ -2385,3 +2385,101 @@ class VotingTestCase(BaseTestCase):
         with self.assertRaises(Exception) as raised:
             v2 = self.create_voting()
         self.assertEqual(IntegrityError, type(raised.exception))
+
+    # Pruebas de modelo Task t061
+
+    # Caso positivo: se crean tres preguntas con tipos de recuento distintos y funciona correctamente
+    def test_type_question_positive_model(self):
+        q0 = Question(desc='Unique option-IDENTITY', option_types=1, type=0)
+        q0.save()
+
+        self.assertEqual(Question.objects.count(), 1)
+
+        q1 = Question(desc='Multiple option-HONDT', option_types=2, type=2)
+        q1.save()
+
+        self.assertNotEqual(q0, q1)
+
+        self.assertEqual(Question.objects.count(), 2)
+
+        q2 = Question(desc='Rank order scale-BORDA', option_types=3, type=1)
+        q2.save()
+
+        self.assertNotEqual(q0, q2)
+        self.assertNotEqual(q1, q2)
+
+        self.assertEqual(Question.objects.count(), 3)
+
+        for i in range(5):
+            opt0 = QuestionOption(question=q0, option='option {}'.format(i + 1))
+            opt0.save()
+        for i in range(5):
+            opt1 = QuestionOption(question=q1, option='option {}'.format(i + 1))
+            opt1.save()
+        for i in range(5):
+            opt2 = QuestionOption(question=q2, option='option {}'.format(i + 1))
+            opt2.save()
+
+        v1 = Voting(name="test voting with 3 kind of questions")
+
+        v1.save()
+        v1.question.add(q0)
+        v1.question.add(q1)
+        v1.question.add(q2)
+
+        a1, _ = Auth.objects.get_or_create(url=settings.BASEURL,
+                                           defaults={'me': True, 'name': 'test auth'})
+        a1.save()
+        v1.auths.add(a1)
+        self.assertEqual(Voting.objects.count(), 1)
+
+    # Caso negativo: se crean 3 votaciones con configuraciones inválidas y salta la excepción
+    def test_type_question_negative_model(self):
+
+        q0 = Question(desc='Unique option-IDENTITY', option_types=1, type=0)
+        q0.save()
+
+        self.assertEqual(Question.objects.count(), 1)
+
+        q1 = Question(desc='Multiple option-HONDT', option_types=2, type=2)
+        q1.save()
+
+        self.assertNotEqual(q0, q1)
+
+        self.assertEqual(Question.objects.count(), 2)
+
+        q2 = Question(desc='Rank order scale-no-BORDA', option_types=3, type=6)
+        q2.save()
+
+        self.assertNotEqual(q0, q2)
+        self.assertNotEqual(q1, q2)
+
+        self.assertEqual(Question.objects.count(), 3)
+
+        with self.assertRaises(Exception) as raised:
+            q3 = self.create_question()
+        self.assertEqual(AttributeError, type(raised.exception))
+
+        for i in range(5):
+            opt0 = QuestionOption(question=q0, option='option {}'.format(i + 1))
+            opt0.save()
+        for i in range(5):
+            opt1 = QuestionOption(question=q1, option='option {}'.format(i + 1))
+            opt1.save()
+        for i in range(5):
+            opt2 = QuestionOption(question=q2, option='option {}'.format(i + 1))
+            opt2.save()
+
+        v1 = Voting(name="test voting with 3 kind of questions")
+
+        v1.save()
+        v1.question.add(q0)
+        v1.question.add(q1)
+        v1.question.add(q2)
+
+        a, _ = Auth.objects.get_or_create(url=settings.BASEURL,
+                                        defaults={'me': True, 'name': 'test auth'})
+        a.save()
+        v1.auths.add(a)
+
+        self.assertEqual(Voting.objects.count(), 1)


### PR DESCRIPTION
Se han realizado test de modelo para validar la creación de preguntas con distintos tipos de recuentos para revisar las restricciones y manejarlas mediante una excepción.