### PR TITLE
Poner readOnly atributos de tallyM y tallyF

### DIFF
--- a/decide/voting/admin.py
+++ b/decide/voting/admin.py
@@ -75,7 +75,7 @@ class VotingAdmin(admin.ModelAdmin):
         
     list_display = ('name', 'start_date', 'end_date', 'started_by')
     readonly_fields = ('start_date', 'end_date', 'pub_key',
-                       'tally', 'postproc', 'started_by')
+                       'tally', 'tallyM', 'tallyF', 'postproc', 'started_by')
     list_filter = (StartedFilter, ('start_date', DateRangeFilter), ('end_date', DateRangeFilter),)
     search_fields = ('name', )
 


### PR DESCRIPTION
Cambiados los atributos de voting tallyM y tallyF a la hora de crear o editar una votacion a readOnly